### PR TITLE
changes to enable position control of the oculus frame in RVIZ based …

### DIFF
--- a/include/oculus_rviz_plugins/ogre_oculus.h
+++ b/include/oculus_rviz_plugins/ogre_oculus.h
@@ -76,6 +76,9 @@ public:
   /// Retrieve the current orientation of the Oculus HMD.
   Ogre::Quaternion getOrientation() const;
 
+  /// Retrieve the current position of the Oculus HMD.
+  ovrPosef getPosition() const;
+
   /// Retrieve either of the two distortion compositors.
   Ogre::CompositorInstance *getCompositor(unsigned int i);
 


### PR DESCRIPTION
…on the DK2 position relative to the tracking camera.

These are the changes we've made to enable positional tracking within RVIZ. This may not be the ideal way to do it but it has worked well for us in conjunction with Kel's navigation framework. We have the Oculus following a target frame, i.e. oculus_nav, that represents the user's world pose. The tf frame being published by the Oculus is the offset relative to oculus_nav, allowing positional changes (leaning in/out, sidestepping) to take place without affecting the navigation frame.

In ogre_oculus.h and ogre_oculus.cpp we added a function (getPosition()) that returned the current pose of the oculus HMD, which we could then use to access the Oculus' position relative to the camera. We then use this function to set the position of the camera node.

In oculus_display.cpp, we get the positions of the two cameras (right and left eyes) in RVIZ, and average them. We also get the orientation of one of the cameras, and then use the averaged position and orientation to set the position and rotation of the TF frame being broadcast. 

As I said earlier, this currently works for us but may not be the ideal way to go about this. I'm new to the Oculus world and open to suggestions of how to improve the structure/function of this addition.
