### PR TITLE
Added ROS Kinetic support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(oculus_rviz_plugins)
 
 # Qt
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-include(${QT_USE_FILE})
+find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+set(QT_LIBRARIES Qt5::Widgets)
+set(QTVERSION ${Qt5Widgets_VERSION})
 add_definitions(-DQT_NO_KEYWORDS -fPIC)
 
 # Catkin
@@ -44,7 +45,7 @@ include_directories(include
 )
 
 # run Qt moc generator
-qt4_wrap_cpp(MOC_FILES
+qt5_wrap_cpp(MOC_FILES
   include/oculus_rviz_plugins/oculus_display.h
   include/oculus_rviz_plugins/fixed_view_controller.h
 )


### PR DESCRIPTION
This commit fixes the crash when loading the Oculus Rift rviz plugin
under ROS Kinetic.

Rviz/rqt switched to qt5 with ROS Kinetic. As stated in the Kinetic
migration log, using qt4 and qt5 alongside doesn't work.

Closes #8.